### PR TITLE
Move compose-html-material to a correct and more-suitable subcategory

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -574,12 +574,6 @@ category("Libraries/Frameworks") {
       setTags("Thread", "Coroutines", "Multithreading", "JVM")
       setPlatforms(JVM)
     }
-    link {
-      github = "huanshankeji/compose-html-material"
-      desc = "Compose HTML Material 3 wrapper components based on Material Web"
-      setTags("Compose HTML", "Material Design", "Material", "Material 3", "Material Web", "Web Components")
-      setPlatforms(JS)
-    }
   }
   subcategory("Functional Programming") {
     link {
@@ -2406,6 +2400,12 @@ category("Libraries/Frameworks") {
       desc = "Unified Compose Multiplatform wrappers of common and Material Design APIs for rendering-based Compose UI and DOM-based Compose HTML"
       setTags("Compose Multiplatform", "Compose UI", "Compose HTML", "compose", "compose-desktop", "ui", "Material Design", "Material", "Material 2", "Material 3", "Material Web", "Kobweb")
       setPlatforms(COMMON, ANDROID, JVM, IOS, WASM, JS)
+    }
+    link {
+      github = "huanshankeji/compose-html-material"
+      desc = "Compose HTML Material 3 wrapper components based on Material Web"
+      setTags("Compose HTML", "Material Design", "Material", "Material 3", "Material Web", "Web Components")
+      setPlatforms(JS)
     }
   }
 }


### PR DESCRIPTION
I first wanted to put it in "Web" but misread the the closing curly bracket and put it in "Coroutines". Now I see the "Web" subcategory is mainly for backend frameworks so I moved it to "Jetpack-Compose". Sorry about this.

Make sure that you are making pull request against [`main`](https://github.com/Heapy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/Heapy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [x] Is this pull request against the branch `main`?
