### PR TITLE
Update KGraphQL location

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -70,7 +70,7 @@ category("Libraries/Frameworks") {
       setTags("web", "http", "rest", "vert.x", "undertow")
     }
     link {
-      github = "aPureBase/KGraphQL"
+      github = "stuebingerb/KGraphQL"
       desc = "A GraphQL implementation written in Kotlin"
       setTags("graphql", "web")
     }


### PR DESCRIPTION
KGraphQL has a new home at https://github.com/stuebingerb/KGraphQL (cf. https://github.com/aPureBase/KGraphQL/blob/main/README.MD)

Checklist: 

- [x] Is this pull request against the branch `main`?
