### PR TITLE
Add ParseRSS Library

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1833,6 +1833,12 @@ category("Libraries/Frameworks") {
       setTags("XML", "StAX", "DSL", "parser")
       setPlatforms(JVM)
     }
+    link {
+      github = "muhrifqii/ParseRSS"
+      desc = "Extensible kotlin library to parse RSS for android, included with retrofit and fuel converter factory"
+      setTags("rss", "feed", "parser", "retrofit")
+      setPlatforms(ANDROID)
+    }
   }
   subcategory("Raspberry Pi") {
     link {


### PR DESCRIPTION
Added 1 Library in `Parsers` sub-category related to RSS Parser named [ParseRSS](https://github.com/muhrifqii/ParseRSS)

Checklist: 

- [x] Is this pull request against the branch `main`?
