### PR TITLE
Add Kensa BDD framework to Testing

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -280,6 +280,11 @@ category("Libraries/Frameworks") {
       setTags("test", "bdd", "gherkin")
     }
     link {
+      github = "kensa-dev/kensa"
+      desc = "A code-first BDD testing framework for Kotlin."
+      setTags("test", "bdd", "junit", "kotest", "testng", "hamkrest")
+    }
+    link {
       github = "EPadronU/balin"
       desc = "Balin is a browser automation library for Kotlin. It's basically a Selenium-WebDriver wrapper library inspired by Geb."
       setTags("test", "selenium", "UI", "automation")


### PR DESCRIPTION
Kensa is a BDD testing framework for Kotlin and Java. Write Given-When-Then tests directly in code — no Gherkin files, no step definitions. Kensa parses your test source at runtime to produce rich HTML reports and sequence diagrams.