### PR TITLE
Add SceneView — 3D & AR SDK for Compose & SwiftUI (KMP)

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -2065,6 +2065,11 @@ category("Libraries/Frameworks") {
   }
   subcategory("Graphics") {
     link {
+      github = "sceneview/sceneview"
+      desc = "3D and AR SDK for Jetpack Compose (Filament) and SwiftUI (RealityKit). Declarative scene graph, 26+ composable node types, ARCore/ARKit integration, Kotlin Multiplatform core."
+      setTags("3d", "ar", "compose", "filament", "arcore", "realitykit", "multiplatform")
+    }
+    link {
       github = "data2viz/data2viz"
       desc = "multiplatform dataviz library, d3js port"
       setTags("d3js", "multiplatform", "svg", "javafx")
@@ -2573,3 +2578,5 @@ category("Libraries/Frameworks") {
     }
   }
 }
+
+# This is wrong - I need to insert inside the Graphics subcategory


### PR DESCRIPTION
## What

Adds [SceneView](https://github.com/sceneview/sceneview) to the **Graphics** subcategory.

## Why

SceneView is the only Compose-native 3D & AR library for Android and the only SwiftUI-native 3D & AR library for Apple platforms:

- **Android**: Jetpack Compose + Filament renderer + ARCore
- **iOS/macOS/visionOS**: SwiftUI + RealityKit + ARKit
- **Web**: Kotlin/JS + Filament.js (WASM)
- **KMP core**: shared math, collision, geometry, physics, animations

Key stats:
- 1.2k+ GitHub stars, 350+ forks
- 13k+ monthly npm downloads (MCP server)
- Successor to Google Sceneform (archived)
- 26+ composable node types
- Used by Fortune 500 companies for AR apps

[npm](https://www.npmjs.com/package/sceneview-mcp) | [Maven Central](https://central.sonatype.com/artifact/io.github.sceneview/sceneview)