### PR TITLE
Add querydsl-ktx to Database subcategory

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -871,6 +871,12 @@ category("Libraries/Frameworks") {
       setTags("database", "query", "jpa")
     }
     link {
+      github = "HarryJhin/querydsl-ktx"
+      desc = "Null-safe infix Kotlin extensions for QueryDSL dynamic queries."
+      setTags("database", "sql", "querydsl", "jpa", "spring-data", "type-safe builder")
+      setPlatforms(JVM)
+    }
+    link {
       github = "Ganet/rxaerospike"
       desc = "RxJava2 wrapper for aerospike-client-java."
       setTags("database", "arospike", "rx", "rxjava2")


### PR DESCRIPTION
Add [querydsl-ktx](https://github.com/HarryJhin/querydsl-ktx) to the Database subcategory.

querydsl-ktx provides null-safe infix Kotlin extensions for QueryDSL dynamic queries. It eliminates manual `BooleanBuilder` null checks by providing eight extension interfaces that turn `if (x != null) builder.and(...)` patterns into declarative infix expressions like `entity.name eq name`.

- Published on Maven Central: `io.github.harryjhin:querydsl-ktx`
- Spring Boot 3.0+, QueryDSL 5.1.0+, Kotlin 1.7+, JDK 17+
- [Documentation](https://harryjhin.github.io/querydsl-ktx/)