### PR TITLE
Add ethora-sdk-android to Android Libraries

### DIFF
--- a/src/main/resources/links/Android.awesome.kts
+++ b/src/main/resources/links/Android.awesome.kts
@@ -391,6 +391,12 @@ category("Android") {
       setTags("android","encryption", "security", "files", "cryptography")
       setPlatforms(ANDROID)
     }
+    link {
+      github = "dappros/ethora-sdk-android"
+      desc = "Native Kotlin/Jetpack Compose chat SDK for Ethora — chat, messaging, AI agents/chatbots; JitPack-published; self-host or hosted."
+      setPlatforms(ANDROID)
+      setTags("chat", "messaging", "sdk", "ai-agents")
+    }
   }
   subcategory("Frameworks") {
     link {


### PR DESCRIPTION
Adds [`dappros/ethora-sdk-android`](https://github.com/dappros/ethora-sdk-android) under `category("Android") { subcategory("Libraries") { ... } }` in `Android.awesome.kts`.

Native Kotlin / Jetpack Compose chat SDK for [Ethora](https://github.com/dappros/ethora), an open-source chat & messaging platform with a built-in AI agent / chatbot framework.

- Repo: https://github.com/dappros/ethora-sdk-android (Apache-2.0)
- Install: JitPack — https://jitpack.io/#dappros/ethora-sdk-android (35 tagged releases through `v1.0.35`)
- Sample app: https://github.com/dappros/ethora-sample-android

Edited the `.awesome.kts` per [CONTRIBUTING.md](https://github.com/Heapy/awesome-kotlin/blob/main/.github/contributing.md).