### PR TITLE
Add spring-saga-kt — coroutine-native Saga orchestrator for Spring Boot

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -235,6 +235,12 @@ category("Libraries/Frameworks") {
       desc = "A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing."
       setTags("kotlin", "ddd", "cqrs", "eventsourcing", "eda", "microservice", "reactive", "mongodb", "r2dbc", "kafka", "test-driven", "opentelemetry", "webflux", "spring-boot")
     }
+    link {
+      github = "BK202503/bk-spring-saga"
+      desc = "Kotlin-first, coroutine-native Saga orchestrator for Spring Boot. Durable resume of interrupted sagas, JDBC (H2/Postgres) and Kafka event modules, autoconfigure starter."
+      setPlatforms(JVM)
+      setTags("kotlin", "spring-boot", "saga", "coroutines", "microservice", "distributed-transactions", "jdbc", "postgres", "kafka")
+    }
   }
   subcategory("Testing") {
     link {


### PR DESCRIPTION
Adds [`BK202503/bk-spring-saga`](https://github.com/BK202503/bk-spring-saga) under `category("Libraries/Frameworks") { subcategory("Web") { ... } }` in `Libraries.awesome.kts`, alongside the existing run of Spring-microservice entries.

### What it is

A Kotlin-first, coroutine-native Saga orchestrator for Spring Boot — fills the gap between heavyweight Axon-style frameworks and out-of-process workflow engines (Temporal/Camunda).

- DSL: `saga<Ctx>("name") { step { action {…}; compensate {…}; retry(…) } }`
- Every action and compensation is a `suspend` function
- Persistence at every step boundary with optimistic locking
- Auto-resume of interrupted sagas on `ApplicationReadyEvent`
- Modules: `saga-core`, `saga-storage-jdbc` (H2/Postgres), `saga-events-kafka`, `saga-spring-boot-starter`

### Project signals

- Apache-2.0 license
- Public on GitHub, `v0.1.0` released 2026-05-31
- JitPack v0.1.0 builds green
- CI runs the full suite including PostgreSQL and Kafka via testcontainers
- README with motivation, install, persistence model, and comparison table

### Checklist

- [x] OSI-approved license (Apache-2.0)
- [x] Public GitHub release (v0.1.0)
- [x] Added in the matching subcategory next to similar Spring-microservice entries
- [x] Description under 200 chars, follows the surrounding format
- [x] Tags consistent with neighbors

Repo: https://github.com/BK202503/bk-spring-saga
Release: https://github.com/BK202503/bk-spring-saga/releases/tag/v0.1.0