### PR TITLE
Add spring-idempotent-kt — Stripe-style @Idempotent for Spring Boot

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -235,6 +235,12 @@ category("Libraries/Frameworks") {
       desc = "A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing."
       setTags("kotlin", "ddd", "cqrs", "eventsourcing", "eda", "microservice", "reactive", "mongodb", "r2dbc", "kafka", "test-driven", "opentelemetry", "webflux", "spring-boot")
     }
+    link {
+      github = "BK202503/bk-spring-idempotent"
+      desc = "Stripe-style @Idempotent annotation for Spring Boot. One annotation, production-ready idempotency-key handling: replay, body-mismatch 422, concurrent 409, pluggable storage (H2/Postgres)."
+      setPlatforms(JVM)
+      setTags("kotlin", "spring-boot", "idempotency", "rest-api", "coroutines", "microservice", "jdbc", "postgres", "annotation-based")
+    }
   }
   subcategory("Testing") {
     link {


### PR DESCRIPTION
Adds [`BK202503/bk-spring-idempotent`](https://github.com/BK202503/bk-spring-idempotent) under `category("Libraries/Frameworks") { subcategory("Web") { ... } }` in `Libraries.awesome.kts`, alongside the existing run of Spring-microservice entries.

### What it is

Stripe-style idempotency-key handling for Spring Boot as a single `@Idempotent` annotation:

```kotlin
@PostMapping("/charges")
@Idempotent
fun charge(@RequestBody req: ChargeRequest): ChargeResponse =
    payments.charge(req)
```

- First call with `Idempotency-Key` → handler runs, response cached
- Same key + same body → cached response replayed verbatim
- Same key + different body → 422 Unprocessable Entity
- Same key, still in flight → 409 Conflict (or wait, configurable)

### Project signals

- Apache-2.0 license
- Public on GitHub, `v0.1.0` released 2026-06-04
- JitPack `v0.1.0` builds green
- CI runs the full suite including PostgreSQL via testcontainers
- README with motivation, install, persistence model, comparison table
- Coroutine-native core, Spring Boot 3 autoconfigure starter, JDBC (H2 + Postgres auto-detect) storage

### Why it fits this list

Fills a real gap not covered by existing entries: there are Java-first
idempotency libraries (Stripe-mason, etc.) but none are Kotlin-native with
Spring Boot 3 autoconfigure and a coroutine-friendly SPI. Sits next to the
existing Spring-microservice entries in the Web subcategory.

### Checklist

- [x] OSI-approved license (Apache-2.0)
- [x] Public GitHub release (v0.1.0)
- [x] Added in the matching subcategory next to similar Spring entries
- [x] Description under 200 chars, follows the surrounding format
- [x] Tags consistent with neighbors

Repo: https://github.com/BK202503/bk-spring-idempotent
Release: https://github.com/BK202503/bk-spring-idempotent/releases/tag/v0.1.0