### PR TITLE
Add krishgok/localdevstack to subcategory tools in Libraries.awesome.kts

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1106,6 +1106,11 @@ category("Libraries/Frameworks") {
       setTags("build", "resource", "gradle")
       setPlatforms(JS)
     }
+    link {
+      github = "krishgok/localdevstack"
+      desc = "Instantly scaffold a containerised local development environment for any service and database"
+      setTags("developer-tools", "cli-tool", "docker")
+    }
   }
   subcategory("Compiler Plugins") {
     link {


### PR DESCRIPTION
Fully built in Kotlin, localDevStack is a one-command scaffold for a Docker-Compose local dev stack (service + database + hot-reload) with coverage for 9 languages and 8 databases with optional companion components.

The differentiator: Scaffold a new service or wrap an existing project, compose-native, no Kubernetes, no host language toolchain required.

Demo - https://github.com/krishgok/localdevstack/blob/main/docs/assets/demo.gif