### PR TITLE
Add spring-outbox-kt — Transactional Outbox for Spring Boot

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -235,6 +235,12 @@ category("Libraries/Frameworks") {
       desc = "A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing."
       setTags("kotlin", "ddd", "cqrs", "eventsourcing", "eda", "microservice", "reactive", "mongodb", "r2dbc", "kafka", "test-driven", "opentelemetry", "webflux", "spring-boot")
     }
+    link {
+      github = "BK202503/bk-spring-outbox"
+      desc = "Transactional Outbox for Spring Boot. Kotlin-first, coroutine-native, autoconfigured. Pluggable storage (H2/Postgres) and Kafka publisher; pairs with bk-spring-saga."
+      setPlatforms(JVM)
+      setTags("kotlin", "spring-boot", "outbox", "transactional-outbox", "microservice", "kafka", "jdbc", "postgres", "coroutines", "eventing")
+    }
   }
   subcategory("Testing") {
     link {


### PR DESCRIPTION
Adds [`BK202503/bk-spring-outbox`](https://github.com/BK202503/bk-spring-outbox) under `category(\"Libraries/Frameworks\") { subcategory(\"Web\") { ... } }` in `Libraries.awesome.kts`, alongside the existing run of Spring-microservice entries.

### What it is

Transactional Outbox for Spring Boot as a single `OutboxPublisher` injection inside `@Transactional`:

```kotlin
@Transactional
fun createOrder(req: CreateOrderRequest): Order {
    val order = orderRepo.save(req.toOrder())
    outbox.publish(
        topic = \"orders\",
        aggregateType = \"Order\",
        aggregateId = order.id,
        eventType = \"OrderCreated\",
        payload = mapper.writeValueAsBytes(OrderCreated(order)),
    )
    return order
}
```

- Same DB transaction wraps the business write and the outbox row → atomic.
- Coroutine-based relay polls the table after commit and forwards each event to Kafka.
- PostgreSQL uses `SELECT … FOR UPDATE SKIP LOCKED` so multiple relay replicas don't double-publish.
- Kafka records carry `outbox_event_id` for downstream dedupe and `aggregateId` as the record key for strict per-aggregate ordering.

### Project signals

- Apache-2.0 license
- Public on GitHub, `v0.1.0` released 2026-06-06
- JitPack `v0.1.0` builds green
- CI runs the full suite including PostgreSQL via testcontainers
- README with motivation, install, comparison, observability section, pairing recipe with [spring-saga-kt](https://github.com/BK202503/bk-spring-saga)

### Why it fits this list

There is no Kotlin-native, Spring Boot autoconfigure-driven Transactional Outbox library in the ecosystem today. Existing options (`Eventuate Tram`, Debezium CDC pipelines) are Java-first or require a separate runtime. This sits naturally next to the existing Spring-microservice entries.

### Checklist

- [x] OSI-approved license (Apache-2.0)
- [x] Public GitHub release (v0.1.0)
- [x] Added in the matching subcategory next to similar Spring entries
- [x] Description under 200 chars, follows the surrounding format
- [x] Tags consistent with neighbors

Repo: https://github.com/BK202503/bk-spring-outbox
Release: https://github.com/BK202503/bk-spring-outbox/releases/tag/v0.1.0