### PR TITLE
Add kexpresso (Kotlin Multiplatform regex DSL)

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1975,6 +1975,12 @@ category("Libraries/Frameworks") {
       setPlatforms(JVM)
     }
     link {
+      github = "elzinko/kexpresso"
+      desc = "Fluent Kotlin Multiplatform DSL for building, analyzing, and explaining regular expressions. Includes ReDoS detection, AST-based example generation, and reverse engineering from raw regex. Compiles to standard Regex with zero match-time overhead."
+      setPlatforms(COMMON, JVM, JS, NATIVE, IOS, WASM)
+      setTags("multiplatform", "regex", "dsl", "redos", "analysis")
+    }
+    link {
       github = "bipokot/Kabu"
       desc = "The fastest way to create complex Kotlin DSL"
       setTags("dsl", "kotlin", "codegenerator")


### PR DESCRIPTION
Adds [kexpresso](https://github.com/elzinko/kexpresso) under `Libraries/Frameworks → DSL`, next to the existing `h0tk3y/regex-dsl` entry.

**What it is:** a fluent Kotlin Multiplatform DSL for building, analyzing, and explaining regular expressions. Compiles to a standard `kotlin.text.Regex` at construction time (0 % match-time overhead).

**Notable features beyond the builder:**
- `describe()` — plain-English explanation of an arbitrary regex (walks an internal AST)
- `analyze()` — flags ReDoS-vulnerable patterns (catastrophic backtracking)
- `examples(n)` — AST-driven generator that produces strings matching the pattern (deterministic per seed)
- `Kexpresso.from(regex)` — reverse-engineers a raw regex into the DSL

**Platforms:** JVM, JS (IR), Wasm, Linux, Windows, macOS, iOS — full DSL lives in `commonMain`.

**Distribution:** published on Maven Central as `io.github.elzinko:kexpresso:0.8.0` (no token required).

Happy to adjust the description, subcategory, or tags if preferred.