### PR TITLE
Add kotlin-security-scanner to Tools

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1046,6 +1046,11 @@ category("Libraries/Frameworks") {
       awesome()
     }
     link {
+      github = "JasminGuberinic/kotlin-security-scanner"
+      desc = "Detekt plugin with 200+ OWASP Top 10 security rules for Kotlin — Spring Boot, Quarkus, Dropwizard, Ktor & Micronaut."
+      setTags("security", "static-analysis", "sast", "owasp", "detekt", "linter")
+    }
+    link {
       github = "Kotlin/kotlinx-kover"
       desc = "Gradle plugin for Kotlin code coverage agents."
       setTags("coverage", "code coverage", "jacoco")


### PR DESCRIPTION
Adds [kotlin-security-scanner](https://github.com/JasminGuberinic/kotlin-security-scanner) under **Libraries/Frameworks → Tools**, next to detekt/ktlint/diktat.

It's a Detekt plugin with 200+ OWASP Top 10 security rules for Kotlin backends — Spring Boot, Quarkus, Dropwizard, Ktor, and Micronaut — published on Maven Central. Already listed on the [detekt 3rd-party marketplace](https://detekt.dev/marketplace/).

- [x] Is this pull request against the branch `main`?