### PR TITLE
Add xberg-io Kotlin libraries (tree-sitter-language-pack, liter-llm, crawlberg, xberg, html-to-markdown)

### DIFF
--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -3694,28 +3694,6 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
-                },
-                {
-                    "name": null,
-                    "github": "xberg-io/crawlberg",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "High-performance web crawling and scraping engine with HTML-to-Markdown conversion and a headless-Chrome fallback — a Kotlin binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "crawler",
-                        "scraping",
-                        "http"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
                 }
             ]
         },
@@ -5460,50 +5438,6 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
-                },
-                {
-                    "name": null,
-                    "github": "xberg-io/xberg",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "Document intelligence library that extracts text, tables, and metadata from PDFs, Office documents, images, and 97+ formats with optional OCR — a Kotlin/Android binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "document",
-                        "extraction",
-                        "ocr",
-                        "pdf"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
-                },
-                {
-                    "name": null,
-                    "github": "xberg-io/html-to-markdown",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "Fast, CommonMark-compliant HTML to Markdown converter — a Kotlin binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "html",
-                        "markdown"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
                 }
             ]
         },
@@ -5619,27 +5553,6 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
-                },
-                {
-                    "name": null,
-                    "github": "xberg-io/tree-sitter-language-pack",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "Pre-built tree-sitter grammars for 300+ languages with a unified parser API — a Kotlin/Android binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "parser",
-                        "tree-sitter"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
                 }
             ]
         },
@@ -7291,28 +7204,6 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
-                },
-                {
-                    "name": null,
-                    "github": "xberg-io/liter-llm",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "Universal LLM API client for 142+ providers with a unified interface and streaming — a Kotlin binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "llm",
-                        "api",
-                        "openai"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
                 }
             ]
         },

--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -3694,6 +3694,28 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
+                },
+                {
+                    "name": null,
+                    "github": "xberg-io/crawlberg",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "High-performance web crawling and scraping engine with HTML-to-Markdown conversion and a headless-Chrome fallback — a Kotlin binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "crawler",
+                        "scraping",
+                        "http"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
                 }
             ]
         },
@@ -5438,6 +5460,50 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
+                },
+                {
+                    "name": null,
+                    "github": "xberg-io/xberg",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "Document intelligence library that extracts text, tables, and metadata from PDFs, Office documents, images, and 97+ formats with optional OCR — a Kotlin/Android binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "document",
+                        "extraction",
+                        "ocr",
+                        "pdf"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
+                },
+                {
+                    "name": null,
+                    "github": "xberg-io/html-to-markdown",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "Fast, CommonMark-compliant HTML to Markdown converter — a Kotlin binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "html",
+                        "markdown"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
                 }
             ]
         },
@@ -5553,6 +5619,27 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
+                },
+                {
+                    "name": null,
+                    "github": "xberg-io/tree-sitter-language-pack",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "Pre-built tree-sitter grammars for 300+ languages with a unified parser API — a Kotlin/Android binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "parser",
+                        "tree-sitter"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
                 }
             ]
         },
@@ -7204,6 +7291,28 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
+                },
+                {
+                    "name": null,
+                    "github": "xberg-io/liter-llm",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "Universal LLM API client for 142+ providers with a unified interface and streaming — a Kotlin binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "llm",
+                        "api",
+                        "openai"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
                 }
             ]
         },

--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1266,6 +1266,12 @@ category("Libraries/Frameworks") {
       setTags("http", "http client", "offline", "okhttp")
     }
     link {
+      github = "xberg-io/crawlberg"
+      desc = "High-performance web crawling and scraping engine with HTML-to-Markdown conversion and a headless-Chrome fallback — a Kotlin binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("crawler", "scraping", "http")
+    }
+    link {
       github = "corbella83/kotliny.network"
       desc = "Simple, powerful and lightweight Kotlin Multiplatform Network Client"
       setTags("http", "http client", "multiplatform")
@@ -1828,6 +1834,18 @@ category("Libraries/Frameworks") {
       setPlatforms(ANDROID, COMMON, IOS, JS, JVM, NATIVE, WASM)
     }
     link {
+      github = "xberg-io/xberg"
+      desc = "Document intelligence library that extracts text, tables, and metadata from PDFs, Office documents, images, and 97+ formats with optional OCR — a Kotlin/Android binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("document", "extraction", "ocr", "pdf")
+    }
+    link {
+      github = "xberg-io/html-to-markdown"
+      desc = "Fast, CommonMark-compliant HTML to Markdown converter — a Kotlin binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("html", "markdown")
+    }
+    link {
       github = "krud-dev/shapeshift"
       desc = "A Kotlin library for intelligent object mapping and conversion between objects."
       setTags("object-mapping", "utility", "conversion", "spring")
@@ -1941,6 +1959,12 @@ category("Libraries/Frameworks") {
       desc = "Extensible XML parser DSL, based on StAX"
       setTags("XML", "StAX", "DSL", "parser")
       setPlatforms(JVM)
+    }
+    link {
+      github = "xberg-io/tree-sitter-language-pack"
+      desc = "Pre-built tree-sitter grammars for 300+ languages with a unified parser API — a Kotlin/Android binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("parser", "tree-sitter")
     }
     link {
       github = "muhrifqii/ParseRSS"
@@ -2519,6 +2543,12 @@ category("Libraries/Frameworks") {
       github = "awslabs/aws-sdk-kotlin"
       desc = "Multiplatform AWS SDK for Kotlin"
       setPlatforms(JVM, ANDROID)
+    }
+    link {
+      github = "xberg-io/liter-llm"
+      desc = "Universal LLM API client for 142+ providers with a unified interface and streaming — a Kotlin binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("llm", "api", "openai")
     }
     link {
       github = "MoviebaseApp/tmdb-api"


### PR DESCRIPTION
Adds five xberg-io libraries with native Kotlin/Android bindings (Rust core, MIT) to Libraries.json:
- **Parsers** — tree-sitter-language-pack (grammars for 300+ languages)
- **API Clients** — liter-llm (universal LLM client, 142+ providers)
- **Http Clients** — crawlberg (crawling/scraping)
- **Misc** — xberg (document intelligence, 97+ formats + OCR) and html-to-markdown

Entries added to the `links/Libraries.json` source data (not the generated README).
