### PR TITLE
Add spikard to Libraries (Web)

### DIFF
--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -770,6 +770,28 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
+                },
+                {
+                    "name": null,
+                    "github": "Goldziher/spikard",
+                    "bitbucket": null,
+                    "kug": null,
+                    "href": null,
+                    "desc": "Rust-powered polyglot HTTP framework with type-safe routing, tower middleware, and OpenAPI/GraphQL/JSON-RPC codegen — a Kotlin/Android binding over a Rust core.",
+                    "platforms": [
+                        "JVM",
+                        "ANDROID"
+                    ],
+                    "tags": [
+                        "web",
+                        "http",
+                        "framework"
+                    ],
+                    "star": null,
+                    "update": null,
+                    "archived": false,
+                    "unsupported": false,
+                    "awesome": true
                 }
             ]
         },

--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -770,28 +770,6 @@
                     "archived": false,
                     "unsupported": false,
                     "awesome": false
-                },
-                {
-                    "name": null,
-                    "github": "Goldziher/spikard",
-                    "bitbucket": null,
-                    "kug": null,
-                    "href": null,
-                    "desc": "Rust-powered polyglot HTTP framework with type-safe routing, tower middleware, and OpenAPI/GraphQL/JSON-RPC codegen — a Kotlin/Android binding over a Rust core.",
-                    "platforms": [
-                        "JVM",
-                        "ANDROID"
-                    ],
-                    "tags": [
-                        "web",
-                        "http",
-                        "framework"
-                    ],
-                    "star": null,
-                    "update": null,
-                    "archived": false,
-                    "unsupported": false,
-                    "awesome": true
                 }
             ]
         },

--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -219,6 +219,12 @@ category("Libraries/Frameworks") {
       setTags("web", "framework", "fullstack")
     }
     link {
+      github = "Goldziher/spikard"
+      desc = "Rust-powered polyglot HTTP framework with type-safe routing, tower middleware, and OpenAPI/GraphQL/JSON-RPC codegen — a Kotlin/Android binding over a Rust core."
+      setPlatforms(JVM, ANDROID)
+      setTags("web", "http", "framework")
+    }
+    link {
       github = "Ahoo-Wang/CoSec"
       desc = "RBAC-based And Policy-based Multi-Tenant Security Framework."
       setTags("kotlin", "security", "rbac", "policy", "multi-tenant", "jwt", "reactive", "web-flux", "spring-boot", "spring-cloud-gateway")


### PR DESCRIPTION
Adds **spikard** (github.com/Goldziher/spikard, MIT, 103★) — a Rust-powered polyglot HTTP framework (type-safe routing, tower-http middleware, OpenAPI/AsyncAPI/GraphQL/JSON-RPC codegen, WebSocket/SSE) exposed via a native Kotlin binding.
