### PR TITLE
Add koog-compose to Jetpack-Compose libraries

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -2571,5 +2571,11 @@ category("Libraries/Frameworks") {
       setTags("ORM", "compiler-plugin", "dsl", "jdbc", "logging", "codegen", "ktor", "spring", "android")
       setPlatforms(JVM, ANDROID)
     }
+    link {
+      github = "brianmwas/koog-compose"
+      desc = "Compose UI integration for the Koog AI agent framework"
+      setTags("jetpack-compose", "compose", "kotlin", "koog", "ai", "agent", "compose-multiplatform")
+      setPlatforms(COMMON, ANDROID, IOS)
+    }
   }
 }


### PR DESCRIPTION
Adds [koog-compose](https://github.com/brianmwas/koog-compose) — a Compose UI integration for the Koog AI agent framework — to the Jetpack-Compose subcategory in `src/main/resources/links/Libraries.awesome.kts`.

Checklist:
- [x] Is this pull request against the branch `main`?
