### PR TITLE
Add Kdrant — a coroutine-first Kotlin client for Qdrant

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -973,6 +973,12 @@ category("Libraries/Frameworks") {
       setTags("database", "hbase", "nosql", "user-interactions", "precomputed", "scale", "spring-webflux")
       setPlatforms(JVM)
     }
+    link {
+      github = "NaCode-Studios/Kdrant"
+      desc = "An idiomatic, coroutine-first Kotlin client for the Qdrant vector database. Suspend APIs, type-safe DSLs, and Spring AI / LangChain4j integrations."
+      setTags("database", "vector-database", "vector-search", "qdrant", "rag", "embeddings", "coroutines")
+      setPlatforms(JVM)
+    }
   }
   subcategory("Tools") {
     link {


### PR DESCRIPTION
Adds **Kdrant** to Libraries/Frameworks → Database.

Kdrant is an idiomatic, coroutine-first Kotlin client for the [Qdrant](https://qdrant.tech) vector database — `suspend` APIs, type-safe DSLs, and Spring AI / LangChain4j integrations. Stable 1.1.0 on Maven Central, Apache-2.0.

Repo: https://github.com/NaCode-Studios/Kdrant