### PR TITLE
Point kassava at the maintained fork

### DIFF
--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -4543,11 +4543,11 @@
                 },
                 {
                     "name": null,
-                    "github": "consoleau/kassava",
+                    "github": "nemecec/kassava",
                     "bitbucket": null,
                     "kug": null,
                     "href": null,
-                    "desc": "This library provides some useful kotlin extension functions for implementing toString() and equals() without all of the boilerplate.",
+                    "desc": "This library provides some useful kotlin extension functions for implementing toString(), equals() and hashCode() without all of the boilerplate.",
                     "platforms": [],
                     "tags": [
                         "hashCode",


### PR DESCRIPTION
Two fields on the existing **kassava** entry in `app-backend/src/main/resources/links/Libraries.json` (Libraries/Frameworks → Misc). No new entry, nothing added to the list.

```diff
-  "github": "consoleau/kassava",
+  "github": "nemecec/kassava",
-  "desc": "... for implementing toString() and equals() without all of the boilerplate.",
+  "desc": "... for implementing toString(), equals() and hashCode() without all of the boilerplate.",
```

### Why

The currently listed repository is dormant and, more importantly, **the library it points to can no longer be depended on**:

- `consoleau/kassava` — last push **2021-03-20**, last release **2.1.0 (Nov 2020)**
- 2.1.0 was published to **JCenter**, which shut down in 2021. Its `au.com.console:kassava` coordinates don't resolve from any live repository.

Someone arriving from kotlin.link today finds a library they can't add to a build.

I've picked Kassava up and am maintaining it now at `nemecec/kassava`. It now has a **3.0.0** release on Maven Central as `dev.nemecec.kassava:kassava` — [live on repo1](https://repo1.maven.org/maven2/dev/nemecec/kassava/kassava/3.0.0/). Same library and API; the Kotlin package moved to match the new group id.

So I'm asking you to point the entry at my own fork. I've kept this to redirecting an entry that already exists rather than adding anything, and the JCenter problem is checkable independently of who maintains the fork.

The `desc` change just adds `hashCode()`, which this entry's own `tags` already list and the library has implemented since 2.1.0.

I left `star`, `update` and the other generated fields untouched, assuming your tooling populates them. The JSON still parses; the diff is exactly these two lines.

### Unrelated, but you may want to know

`.github/contributing.md` points contributors at `src/main/resources/links/${category}.awesome.kts`. That path doesn't exist on `main` any more — the link data is the JSON under `app-backend/src/main/resources/links/`, and the remaining `.awesome.kts` files are articles. GitHub code search still surfaces the old path too, so it's an easy wrong turn. Happy to send a separate PR fixing the guide if that would help.
