### PR TITLE
Add admob-compose-multiplatform to Multiplatform libraries

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1955,6 +1955,13 @@ category("Libraries/Frameworks") {
       setTags("multiplatform", "arch", "architecture", "mvi")
       setPlatforms(COMMON, JVM, JS, ANDROID, IOS, NATIVE, WASM)
     }
+    link {
+      github = "Meet-Miyani/admob-compose-multiplatform"
+      href = "https://ads.avinya.dev"
+      desc = "Google AdMob SDK for Compose Multiplatform (Android & iOS) supporting Banner, Interstitial, Rewarded, App Open, and Native ads."
+      setPlatforms(COMMON, ANDROID, IOS)
+      setTags("admob", "ads", "compose-multiplatform", "kotlin-multiplatform", "monetization", "android", "ios")
+    }
   }
   subcategory("Cryptography") {
     link {


### PR DESCRIPTION
Make sure that you are making pull request against [`main`](https://github.com/Heapy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/Heapy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [x] Is this pull request against the branch `main`?

### Summary

Adds [admob-compose-multiplatform](https://github.com/Meet-Miyani/admob-compose-multiplatform) to the **Libraries/Frameworks -> Multiplatform** section.

- **Repository:** [Meet-Miyani/admob-compose-multiplatform](https://github.com/Meet-Miyani/admob-compose-multiplatform)
- **Documentation:** https://ads.avinya.dev
- **Description:** Google AdMob SDK for Compose Multiplatform (Android & iOS) supporting Banner, Interstitial, Rewarded, App Open, and Native ads.
- **Platforms:** Common, Android, iOS
