### PR TITLE
Add Kormium to Libraries/Database

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -973,6 +973,12 @@ category("Libraries/Frameworks") {
       setTags("database", "hbase", "nosql", "user-interactions", "precomputed", "scale", "spring-webflux")
       setPlatforms(JVM)
     }
+    link {
+      github = "kormium/kormium"
+      desc = "Type-safe ORM and SQL DSL for Kotlin Multiplatform, with tables, entities, transactions and migrations shared across server and client."
+      setTags("database", "orm", "sql", "query", "type-safe builder", "migrations", "postgres", "mysql", "sqlite", "jdbc", "r2dbc", "ktor", "multiplatform")
+      setPlatforms(COMMON, JVM, ANDROID, IOS, NATIVE, JS, WASM)
+    }
   }
   subcategory("Tools") {
     link {


### PR DESCRIPTION
Adds [Kormium](https://github.com/kormium/kormium) to **Libraries/Frameworks → Database**.

Kormium is a type-safe ORM and SQL DSL for Kotlin Multiplatform: tables, entities, typed predicates, transactions, migrations, joins and aggregations, with one schema and query model shared across server and client.

- Core runs on JVM, Kotlin/Native, Android and iOS; Node and browser (Wasm) are experimental.
- Backends: PostgreSQL, MySQL/MariaDB, SQLite; async r2dbc (PostgreSQL, MySQL).
- Ktor integration modules, published to Maven Central under `io.github.kormium`.
- Apache 2.0 licensed, actively maintained (latest release 0.11.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)