### PR TITLE
Add jpa-spec-kotlin-dsl

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -973,6 +973,13 @@ category("Libraries/Frameworks") {
       setTags("database", "hbase", "nosql", "user-interactions", "precomputed", "scale", "spring-webflux")
       setPlatforms(JVM)
     }
+    link {
+      github = "alfonsoristorato/jpa-spec-kotlin-dsl"
+      href = "https://alfonsoristorato.github.io/jpa-spec-kotlin-dsl"
+      desc = "Type-safe Kotlin DSL for building JPA Specification, PredicateSpecification and Predicate queries using property references."
+      setTags("database", "jpa", "spring", "spring-data", "dsl", "kotlin-dsl", "query", "jpa-specification")
+      setPlatforms(JVM)
+    }
   }
   subcategory("Tools") {
     link {
@@ -2570,13 +2577,6 @@ category("Libraries/Frameworks") {
       desc = "A modern ORM framework designed for Kotlin based on the compiler plugin, which is suitable for both backend and mobile applications, support multi-database. Powerful, high performance, easy to use."
       setTags("ORM", "compiler-plugin", "dsl", "jdbc", "logging", "codegen", "ktor", "spring", "android")
       setPlatforms(JVM, ANDROID)
-    }
-    link {
-      github = "alfonsoristorato/jpa-spec-kotlin-dsl"
-      href = "https://alfonsoristorato.github.io/jpa-spec-kotlin-dsl"
-      desc = "Type-safe Kotlin DSL for building JPA Specification, PredicateSpecification and Predicate queries using property references."
-      setTags("database", "jpa", "spring", "spring-data", "dsl", "kotlin-dsl", "query", "jpa-specification")
-      setPlatforms(JVM)
     }
   }
 }

--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -2571,5 +2571,12 @@ category("Libraries/Frameworks") {
       setTags("ORM", "compiler-plugin", "dsl", "jdbc", "logging", "codegen", "ktor", "spring", "android")
       setPlatforms(JVM, ANDROID)
     }
+    link {
+      github = "alfonsoristorato/jpa-spec-kotlin-dsl"
+      href = "https://alfonsoristorato.github.io/jpa-spec-kotlin-dsl"
+      desc = "Type-safe Kotlin DSL for building JPA Specification, PredicateSpecification and Predicate queries using property references."
+      setTags("database", "jpa", "spring", "spring-data", "dsl", "kotlin-dsl", "query", "jpa-specification")
+      setPlatforms(JVM)
+    }
   }
 }


### PR DESCRIPTION
Adds `jpa-spec-kotlin-dsl` - a type-safe Kotlin DSL for building Spring Data JPA `Specification`, `PredicateSpecification` and `Predicate` queries using property references (e.g. `User::name.equal("Alice") and User::age.greaterThan(18)`).

- Supports both `Specification` and the newer `PredicateSpecification` (Spring Data JPA 3.4+)
- full docs + KDoc API reference: https://alfonsoristorato.github.io/jpa-spec-kotlin-dsl/

Appreciate that https://github.com/consoleau/kotlin-jpa-specification-dsl already exists, and is present in this list, but it has not been updated for a while now + I hope that with this library there is a lot more covered (including the new  `PredicateSpecification`, a module for `Hibernate` specifically, easier way to `join` and `fetch` and a bunch more stuff)


