### PR TITLE
Fix ShopSavvy SDK repo name

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -2566,7 +2566,7 @@ category("Libraries/Frameworks") {
       setPlatforms(JVM, JS, ANDROID, NATIVE, COMMON)
     }
     link {
-      github = "shopsavvy/shopsavvy-sdk-kotlin"
+      github = "shopsavvy/sdk-kotlin"
       desc = "Kotlin SDK for the ShopSavvy Data API — product lookups, real-time pricing, and price history."
       setPlatforms(JVM, ANDROID)
       setTags("api-client", "shopping", "e-commerce", "price-comparison")


### PR DESCRIPTION
The entry added in #1111 points at `shopsavvy/shopsavvy-sdk-kotlin`, which returns 404. The real repository is `shopsavvy/sdk-kotlin`.