### PR TITLE
Add forkOf field to link model

### DIFF
--- a/app-backend/src/main/kotlin/usecases/links/Links.kt
+++ b/app-backend/src/main/kotlin/usecases/links/Links.kt
@@ -77,6 +77,13 @@ class LinkSource {
 data class LinkV1(
     val name: String? = null,
     val github: String? = null,
+    /**
+     * Upstream repository this entry was forked from.
+     *
+     * [github] points to the fork we show. If the upstream becomes more
+     * recently updated than the fork, the upstream should be shown instead.
+     */
+    val forkOf: String? = null,
     val bitbucket: String? = null,
     val kug: String? = null,
     val href: String? = null,

--- a/app-backend/src/main/resources/links/Libraries.json
+++ b/app-backend/src/main/resources/links/Libraries.json
@@ -4544,6 +4544,7 @@
                 {
                     "name": null,
                     "github": "nemecec/kassava",
+                    "forkOf": "consoleau/kassava",
                     "bitbucket": null,
                     "kug": null,
                     "href": null,


### PR DESCRIPTION
Follow-up to #1154.

That PR redirected the kassava entry from `consoleau/kassava` to the maintained fork `nemecec/kassava`. The redirect is right, but the link to the original repo is now lost — nothing in the data says where the fork came from.

This adds a `forkOf` field to `LinkV1` and uses it on the kassava entry:

```json
"github": "nemecec/kassava",
"forkOf": "consoleau/kassava",
```

`github` stays the repo we show. `forkOf` records the upstream.

### Not implemented yet

The intended behaviour: if the upstream repo is updated more recently than the fork, show the upstream as the main entry instead. This PR is only the model and the data — no processing logic.

`:app-backend:compileKotlin` and `:app-backend:compileTestKotlin` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)